### PR TITLE
Minor Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You can use the modrinth maven to add this to your project. Add this to your rep
 
 ```
 repositories {
-    maven { url = "https://maven.is-immensely.gay" }
+    maven { url = "https://maven.is-immensely.gay/releases" }
 }
 ```
 And this to your dependencies. Don't forget to change "VERSION" to the latest released version number which can be found [here](https://maven.is-immensely.gay/#/releases/dev/mayaqq/NexusFrame)

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.6-SNAPSHOT'
+    id 'fabric-loom' version '1.8-SNAPSHOT'
     id 'maven-publish'
     id "me.modmuss50.mod-publish-plugin" version "0.4.5"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,9 +2,9 @@ org.gradle.jvmargs=-Xmx1G
 org.gradle.parallel=true
 
 # Fabric Properties
-	minecraft_version=1.21
-	yarn_mappings=1.21+build.1
-	loader_version=0.15.11
+	minecraft_version=1.21.1
+	yarn_mappings=1.21+build.3
+	loader_version=0.16.9
 
 # Mod Properties
 	mod_version = 2.1.0+1.21
@@ -12,5 +12,5 @@ org.gradle.parallel=true
 	archives_base_name = nexus-frame
 
 # Dependencies
-	fabric_version=0.100.1+1.21
-	polymer_version=0.9.1+1.21
+	fabric_version=0.108.0+1.21.1
+	polymer_version=0.9.18+1.21.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ org.gradle.parallel=true
 	loader_version=0.15.11
 
 # Mod Properties
-	mod_version = 2.0.0+1.21
+	mod_version = 2.1.0+1.21
 	maven_group = dev.mayaqq
 	archives_base_name = nexus-frame
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,5 @@
+jdk:
+  - openjdk21
+before_install:
+  - sdk install java 21.0.2-tem
+  - sdk use java 21.0.2-tem

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,5 +1,0 @@
-jdk:
-  - openjdk21
-before_install:
-  - sdk install java 21.0.2-tem
-  - sdk use java 21.0.2-tem

--- a/src/main/java/dev/mayaqq/nexusframe/api/multiblock/Multiblock.java
+++ b/src/main/java/dev/mayaqq/nexusframe/api/multiblock/Multiblock.java
@@ -115,6 +115,7 @@ public class Multiblock {
                 }
             }
         }
+        previewing = !previewing;
     }
 
     public void rotate() {

--- a/src/main/java/dev/mayaqq/nexusframe/api/multiblock/Multiblock.java
+++ b/src/main/java/dev/mayaqq/nexusframe/api/multiblock/Multiblock.java
@@ -1,6 +1,5 @@
 package dev.mayaqq.nexusframe.api.multiblock;
 
-import dev.mayaqq.nexusframe.NexusFrame;
 import dev.mayaqq.nexusframe.mixin.BucketItemMixin;
 import eu.pb4.polymer.virtualentity.api.ElementHolder;
 import eu.pb4.polymer.virtualentity.api.attachment.ChunkAttachment;
@@ -84,6 +83,26 @@ public class Multiblock {
                     BlockPos blockPos = corner.add(j, i, k);
                     Predicate<BlockState> predicate = predicates.get(pattern[i][j][k]);
                     boolean isRightBlock = predicate.test(world.getBlockState(blockPos));
+
+                    // if the block is not the right block, return false
+                    if (!isRightBlock) result = false;
+                }
+            }
+        }
+        return result;
+    }
+
+    public void preview(BlockPos mainBlockPos, World world) {
+        BlockPos corner = findOffset(mainBlockPos);
+        if (corner == null) {
+            LOGGER.error("Multiblock pattern does not contain $");
+        }
+
+        for (int i = 0; i < pattern.length; i++) {
+            for (int j = 0; j < pattern[i].length; j++) {
+                for (int k = 0; k < pattern[i][j].length; k++) {
+                    BlockPos blockPos = corner.add(j, i, k);
+                    Predicate<BlockState> predicate = predicates.get(pattern[i][j][k]);
                     //if the block is already in the map, remove it
                     if (shouldPreview) {
                         // if the elements are being previewed, remove the previews
@@ -97,13 +116,9 @@ public class Multiblock {
                             previewElements.put(blockPos, previewElement);
                         }
                     }
-                    // if the block is not the right block, return false
-                    if (!isRightBlock) result = false;
                 }
             }
         }
-        previewing = !previewing;
-        return result;
     }
 
     public void rotate() {

--- a/src/main/java/dev/mayaqq/nexusframe/api/multiblock/Multiblock.java
+++ b/src/main/java/dev/mayaqq/nexusframe/api/multiblock/Multiblock.java
@@ -68,7 +68,6 @@ public class Multiblock {
         //find the $ in the pattern
         BlockPos corner = findOffset(mainBlockPos);
         if (corner == null) {
-            LOGGER.error("Multiblock pattern does not contain $");
             return false;
         }
 
@@ -94,9 +93,6 @@ public class Multiblock {
 
     public void preview(BlockPos mainBlockPos, World world) {
         BlockPos corner = findOffset(mainBlockPos);
-        if (corner == null) {
-            LOGGER.error("Multiblock pattern does not contain $");
-        }
 
         for (int i = 0; i < pattern.length; i++) {
             for (int j = 0; j < pattern[i].length; j++) {
@@ -149,6 +145,7 @@ public class Multiblock {
                 }
             }
         }
+        LOGGER.error("Multiblock pattern does not contain $");
         return null;
     }
 


### PR DESCRIPTION
Couple small things were done here, addresses #1 
- Seperates previewing a multiblock into a new method, which allows for checks that do not force a preview as well as checking on ticks in block entities for valid structures
- With the new method, moved the `$` error log into the offset method rather then calling it in two separate places and causing duplicate logs
- Bumped the semver up one minor version
- Updated to 1.21.1, and updated Fabric API, Loom version, Yarn and Gradle to ensure Nexus is in most stable spot
- Corrected the maven in the ReadMe to show the right address to the repo